### PR TITLE
Feat/add helper scripts

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,0 +1,5 @@
+# Helper Scripts
+
+Contain scripts that helps to automate daily tasks for Runops users.
+
+- [Secret Manager](./secret-manager.md) Automate Creation of secrets in Kubernetes / AWS Secret Manager

--- a/helpers/secret-manager.md
+++ b/helpers/secret-manager.md
@@ -35,6 +35,8 @@ kubectl apply -n demo-sm -f ../kubernetes/mysql-deploy.yaml
 
 4. Deploy an agent
 
+> Make sure to add the proper AWS credentials in the parameters below
+
 ```sh
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/runopsio/agent/releases/latest |jq .assets[1].browser_download_url -r)
 # WARNING: If you have agents running in production, this operation will break then!
@@ -110,4 +112,3 @@ So you can CREATE, INSERT and SELECT but not delete records.
 # get the secret id in the logs of the task
 aws secretsmanager describe-secret --secret-id <secret-id>
 ```
-

--- a/helpers/secret-manager.md
+++ b/helpers/secret-manager.md
@@ -1,0 +1,113 @@
+## Secret Manager
+
+This script helps to automate the creation of users in MySQL and propagates then on [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and save the credentials for long term in the AWS Secret Manager.
+
+### Configuration / Requirements
+
+- A Kubernetes cluster with a valid Kubeconfig valid file
+- MySQL user with permission to CREATE users and GRANT then permissions
+- AWS Secret Manager credentials to create secrets
+- [Helm 3](https://helm.sh/docs/intro/install/)
+
+### Getting Started
+
+1. Clone this repository
+
+```sh
+git clone git@github.com:runopsio/example-apps.git && cd example-apps/helpers
+```
+
+2. Generate a base64 kubeconfig file for a namespace, for testing purpose let's use the kubeconfig from a local installation
+
+```sh
+NAMESPACE=demo-sm
+KUBECONFIG_DATA=$(kubectl config view -o json --minify --raw |jq . -c |base64)
+```
+
+To generate a Kubeconfig file from a service account, see [this gist](https://gist.github.com/innovia/fbba8259042f71db98ea8d4ad19bd708)
+
+3. Deploy a MySQL instance in Kubernetes
+
+```sh
+kubectl create ns demo-sm
+kubectl apply -n demo-sm -f ../kubernetes/mysql-deploy.yaml
+```
+
+4. Deploy an agent
+
+```sh
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/runopsio/agent/releases/latest |jq .assets[1].browser_download_url -r)
+# WARNING: If you have agents running in production, this operation will break then!
+AGENT_TOKEN=$(runops agents create-token -f)
+helm upgrade --install agent $LATEST_RELEASE \
+    --set config.token=$AGENT_TOKEN \
+    --set config.tags=dev \
+    --set env_var[0].env=SECRET_MANAGER_CONFIG \
+    --set env_var[0].vars.MYSQL_GRANT_USER=root \
+    --set env_var[0].vars.MYSQL_GRANT_PASSWORD=1a2b3c4d \
+    --set env_var[0].vars.MYSQL_GRANT_HOST=mysql.demo-sm \
+    --set env_var[0].vars.MYSQL_GRANT_LIST="SELECT\,INSERT\,UPDATE\,CREATE" \
+    --set env_var[0].vars.MYSQL_GRANT_DB=testdb \
+    --set env_var[0].vars.AWS_ACCESS_KEY_ID= \
+    --set env_var[0].vars.AWS_SECRET_ACCESS_KEY= \
+    --set env_var[0].vars.AWS_DEFAULT_REGION= \
+    --set env_var[0].vars.KUBECONFIG_DATA="$KUBECONFIG_DATA" \
+    --set env_var[0].vars.SECRET_NAMESPACE=demo-sm \
+    --set env_var[0].vars.AWS_SECRET_PREFIX=runops/dev/ \
+    --set env_var[0].vars.KUBERNETES_SECRET_PREFIX=runops-dev- \
+    --namespace demo-sm
+```
+
+5. Create a target
+
+```sh
+runops targets create --type python --name myapp-dev \
+    --secret_provider env-var \
+    --secret_path SECRET_MANAGER_CONFIG \
+    --tags dev
+```
+
+6. Execute a task to create a new user on MySQL
+
+The output will contain the name of the secret of the AWS secret manager and Kubernetes
+
+```sh
+runops tasks create -t myapp-dev -f ./secret-manager.py
+```
+
+7. Try to access the database with those credentials and create a table
+
+```sh
+kubectl port-forward -n demo-sm deploy/mysql 3306 3306
+cat - > /tmp/create-table.sql <<EOF
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    start_date DATE,
+    due_date DATE,
+    status TINYINT NOT NULL,
+    priority TINYINT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)  ENGINE=INNODB;
+EOF
+MYSQL_USER=$(kubectl get secrets -n demo-sm -l managed-by=runops -o json  |jq '.items[0].data | .user |@base64d' -r)
+MYSQL_PASS=$(kubectl get secrets -n demo-sm -l managed-by=runops -o json  |jq '.items[0].data | .password |@base64d' -r)
+
+mysql -u$MYSQL_USER -p$MYSQL_PASS -D testdb -h 127.0.0.1 < /tmp/create-table.sql
+mysql -u$MYSQL_USER -p$MYSQL_PASS -D testdb -h 127.0.0.1 -Bse "INSERT INTO tasks (title, status, priority) VALUES ('foo', 1, 1)"
+mysql -u$MYSQL_USER -p$MYSQL_PASS -D testdb -h 127.0.0.1 -Bse "SELECT * FROM tasks"
+1	foo	NULL	NULL	1	1	NULL	2022-02-18 21:19:53
+mysql -u$MYSQL_USER -p$MYSQL_PASS -D testdb -h 127.0.0.1 -Bse "DELETE FROM tasks where title = 'foo'"
+ERROR 1142 (42000) at line 1: DELETE command denied to user 'usr_7b1e36c36114'@'127.0.0.1' for table 'tasks'
+```
+
+So you can CREATE, INSERT and SELECT but not delete records.
+
+8. Check if the secret manager has the stored credentials
+
+```sh
+# get the secret id in the logs of the task
+aws secretsmanager describe-secret --secret-id <secret-id>
+```
+

--- a/helpers/secret-manager.py
+++ b/helpers/secret-manager.py
@@ -1,0 +1,267 @@
+# Copyright (c) Runops Inc
+# https://runops.io
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#!/usr/bin/env python
+import boto3
+import random
+import string
+import secrets
+import logging
+import json
+import sys
+import base64
+import time
+import tempfile
+import os
+import re
+from sqlalchemy import create_engine
+from kubernetes import client, config
+
+"""
+Creates a MySQL random user with secure random password and
+store in AWS Secret Manager and Kubernetes Secrets.
+In order to run this script check the required environment variables
+needed to run this script.
+
+To run this script the following dependencies are required:
+
+- A valid kubernetes config file
+- A MySQL admin credentials to create users and grant permissions
+- Secret manager access to create secrets
+
+This script could be used in multiple environments using Runops, check
+more instructions on README.md.
+"""
+
+logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s  %(name)s %(levelname)s - %(message)s',
+        stream=sys.stdout,
+        datefmt="%Y-%m-%dT%H:%M:%S%z")
+log = logging.getLogger(__name__)
+
+REQUIRED_ENVIRONMENTS = {
+    # required for creating and granting new users permissions in a database
+    'MYSQL_GRANT_USER': 'required',
+    'MYSQL_GRANT_PASSWORD': 'required',
+    'MYSQL_GRANT_HOST': 'required',
+    'MYSQL_GRANT_DB': 'required',
+    'MYSQL_GRANT_LIST': 'required',
+
+    # required for acessing the AWS Secret Manager and storing
+    # the credentials of new MySQL users
+    'AWS_ACCESS_KEY_ID': 'required',
+    'AWS_SECRET_ACCESS_KEY': 'required',
+    'AWS_DEFAULT_REGION': 'required',
+
+    # [OPTIONAL] it will be used as prefix name to AWS secret manager and Kubernetes.
+    # AWS Secret Prefix must contain only alphanumeric characters and the characters /_+=.@- 
+    'AWS_SECRET_PREFIX': 'optional',
+    'KUBERNETES_SECRET_PREFIX': 'optional',
+    
+    # required for creating Kubernetes Secrets containing
+    # the credentials of MySQL users. It should be a base64 kubeconfig file
+    'KUBECONFIG_DATA': 'required',
+    # the namespace to create the secret.
+    'SECRET_NAMESPACE': 'required',
+}
+REQUIRED_ENVIRONMENTS_LIST = REQUIRED_ENVIRONMENTS.keys()
+MYSQL_GRANT_ALLOWED_LIST = ['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'CREATE',
+    'DROP', 'RELOAD', 'PROCESS', 'REFERENCES', 'INDEX', 'ALTER', 'SHOW DATABASES',
+    'CREATE TEMPORARY TABLES', 'LOCK TABLES', 'EXECUTE', 'REPLICATION SLAVE',
+    'REPLICATION CLIENT', 'CREATE VIEW', 'SHOW VIEW', 'CREATE ROUTINE', 
+    'ALTER ROUTINE', 'CREATE USER', 'EVENT']
+
+def parse_runtime_credentials():
+    """
+    Will parse the runtime credentials required to run this program
+    and validate if all environments are present.
+    """
+    for env in REQUIRED_ENVIRONMENTS_LIST:
+        if env not in os.environ and REQUIRED_ENVIRONMENTS[env] == 'required':
+            return None, 'Missing required environment variable {}'.format(env)
+    
+    for grant in os.environ['MYSQL_GRANT_LIST'].split(','):
+        if grant not in MYSQL_GRANT_ALLOWED_LIST:
+            return None, 'MySQL Grant not allowed, found={}, allowed={}'.format(
+                grant, ','.join(MYSQL_GRANT_ALLOWED_LIST),
+            )
+
+    k8s_secret_prefix = os.environ.get('KUBERNETES_SECRET_PREFIX', 'runops-')
+    if k8s_secret_prefix:
+        if len(k8s_secret_prefix) > 20:
+            return None, 'KUBERNETES_SECRET_PREFIX reach max length size (20)'
+        if re.search('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$', k8s_secret_prefix):
+            return None, 'KUBERNETES_SECRET_PREFIX contains unsupported characteres'
+
+    aws_secret_prefix = os.environ.get('AWS_SECRET_PREFIX', 'runops/')
+    if aws_secret_prefix:
+        if len(aws_secret_prefix) > 150:
+            return None, 'AWS_SECRET_PREFIX reach max length size (150)'
+
+    # populate defaults
+    os.environ['KUBERNETES_SECRET_PREFIX'] = k8s_secret_prefix
+    os.environ['AWS_SECRET_PREFIX'] = aws_secret_prefix
+
+    return dict(map(lambda e: (e, os.environ[e]), REQUIRED_ENVIRONMENTS_LIST)), None
+
+def get_sm_cred(secret_name):
+    try:
+        client = boto3.client('secretsmanager')
+        resp = client.get_secret_value(SecretId=secret_name)
+        print(resp)
+        return {'ARN': resp['ARN'],
+                'Name': resp['Name'], 
+                'VersionId': resp['VersionId'], 
+                'SecretString': resp['SecretString'],
+                'VersionStages': resp['VersionStages']}, None
+    except Exception as ex:
+        return None, e
+
+def random_password(password_lenght=25):
+    options = string.ascii_lowercase + string.ascii_uppercase
+    options += string.digits + '_&#-<>=+|~^*'
+    return ''.join(random.sample(options, password_lenght))
+
+def random_credentials():
+    return 'usr_' + ''.join(secrets.token_hex(6)), random_password()
+
+def generate_secret_name(secret_prefix, secret_suffix):
+    return secret_prefix + secret_suffix
+
+def create_db_user(runtime_cred, grant_list):
+    conn_string = 'mysql+pymysql://{user}:{password}@{host}:3306'.format(
+        user=runtime_cred['MYSQL_GRANT_USER'],
+        password=runtime_cred['MYSQL_GRANT_PASSWORD'],
+        host=runtime_cred['MYSQL_GRANT_HOST'])
+    try:
+        user, passwd = random_credentials()
+        with create_engine(conn_string).connect() as conn:
+            conn.execute("CREATE USER %s@'%%' IDENTIFIED BY %s", (user, passwd))
+            # TODO: validate grant db to prevent sql injections!
+            conn.execute("GRANT {} ON {}.* TO '{}'@'%%'"
+                .format(grant_list, runtime_cred['MYSQL_GRANT_DB'], user))
+        return {'user': user, 'password': passwd}, None
+    except Exception as e:
+        return None, e
+
+def create_sm_credentials(name, db_credentials):
+    try:
+        client = boto3.client('secretsmanager')
+        resp = client.create_secret(
+            Name=name,
+            Description='Created by Runops Template',
+            SecretString=json.dumps(db_credentials),
+            Tags=[
+                {
+                    'Key': 'managed-by',
+                    'Value': 'runops'
+                },
+            ]
+        )
+        return {'ARN': resp['ARN'],
+                'VersionId': resp['VersionId']}, None
+    except Exception as e:
+        return None, e
+
+class KubeConfigWriter(object):
+    def __init__(self, kubeconfig_base64):
+        """ Given a kubeconfig raw config in base64: kubectl config view --minify --raw -o json |jq -c |base64
+        Decode it and write to a temporary file and return its path,
+        on exit delete the temporary file
+        """
+        self.kubeconfig_base64 = kubeconfig_base64
+        self.temp_kubeconfig_file = None
+      
+    def __enter__(self):
+        raw_kubeconfig = base64.b64decode(self.kubeconfig_base64)
+        self.temp_kubeconfig_file = tempfile.NamedTemporaryFile()
+        self.temp_kubeconfig_file.write(raw_kubeconfig)
+        self.temp_kubeconfig_file.seek(0)
+        return self.temp_kubeconfig_file.name
+  
+    def __exit__(self, *args, **kwargs):
+        self.temp_kubeconfig_file.close()
+
+def dict_to_base64(data):
+    return dict(map(lambda k : (k, base64.b64encode(data[k].encode('ascii')).decode()), data))
+
+def create_k8s_secret(kubeconfig_base64, secret_name, namespace, db_credentials):
+    try:
+        with KubeConfigWriter(kubeconfig_base64) as kubeconfig_path:
+            config.load_kube_config(config_file=kubeconfig_path)
+            api_instance = client.CoreV1Api()
+            sec = client.V1Secret()
+            sec.metadata = client.V1ObjectMeta(
+                name=secret_name,
+                labels={'managed-by': 'runops'})
+            sec.type = 'Opaque'
+            sec.data = dict_to_base64(db_credentials)
+            resp = api_instance.create_namespaced_secret(namespace=namespace, body=sec)
+            return {'uid': resp.metadata.uid,
+                    'resource_version': resp.metadata.resource_version,
+                    'namespace': resp.metadata.namespace}, None
+    except Exception as e:
+        return None, e
+
+if __name__ == '__main__':
+    log.info('Parsing runtime credentials ...')
+    runtime_cred, err = parse_runtime_credentials()
+    if err: raise Exception(err)
+    log.info('done.')
+
+    log.info('Creating database user on MySQL with grants {} ...'.format(runtime_cred['MYSQL_GRANT_LIST']))
+    db_credentials, err = create_db_user(runtime_cred, runtime_cred['MYSQL_GRANT_LIST'])
+    if err:
+        raise Exception('Failed to create credentials on database, err={}'.format(err))
+    log.info('done. user={}'.format(db_credentials['user']))
+
+    secret_suffix = secrets.token_hex(8)
+    aws_secret_name = generate_secret_name(runtime_cred['AWS_SECRET_PREFIX'], secret_suffix)
+    log.info('Creating database credentials on AWS Secret Manager. name={}, user={}'
+        .format(aws_secret_name, db_credentials['user']))
+    
+    resp, err = create_sm_credentials(
+        aws_secret_name,
+        {**db_credentials, 
+        'host': runtime_cred['MYSQL_GRANT_HOST'], 
+        'database': runtime_cred['MYSQL_GRANT_DB']},
+    )
+    if err:
+        raise Exception('Failed to create credentials on AWS Secret Manager, err={}'.format(err))
+    log.info('done. arn={}, version_id={}'.format(resp['ARN'], resp['VersionId']))
+
+    k8s_secret_name = generate_secret_name(runtime_cred['KUBERNETES_SECRET_PREFIX'], secret_suffix)
+    log.info("Creating credentials on Kubernetes Secret with name={} ...".format(k8s_secret_name))
+    resp, err = create_k8s_secret(
+        runtime_cred['KUBECONFIG_DATA'], 
+        k8s_secret_name,
+        runtime_cred['SECRET_NAMESPACE'],
+        {**db_credentials, 
+        'host': runtime_cred['MYSQL_GRANT_HOST'], 
+        'database': runtime_cred['MYSQL_GRANT_DB']},
+    )
+    if err:
+        raise Exception('Failed to create credentials on Kubernetes Secret, err={}'.format(err))
+    log.info('done. name={}, uid={}, resource_version={}, namespace={}'
+        .format(
+            k8s_secret_name, resp['uid'],
+            resp['resource_version'], resp['namespace'],
+        ))


### PR DESCRIPTION
Add secret-manager script to automate the creation of MySQL credentials and propagate then to Kubernetes Secret and AWS Secret Manager.